### PR TITLE
Fetching emergency numbers from external API

### DIFF
--- a/EmergencyNumber/src/main/AndroidManifest.xml
+++ b/EmergencyNumber/src/main/AndroidManifest.xml
@@ -48,19 +48,19 @@
             android:theme="@style/AppTheme" />
 
         <!--Send Receiver-->
-        <receiver android:name="com.lukaspaczos.emergencynumber.broadcast.receiver.SendBroadcastReceiver">
+        <receiver android:name=".communication.broadcast.SendBroadcastReceiver">
             <intent-filter>
                 <action android:name="message_send" />
             </intent-filter>
         </receiver>
         <!--Delivery Receiver-->
-        <receiver android:name="com.lukaspaczos.emergencynumber.broadcast.receiver.DeliveryBroadcastReceiver">
+        <receiver android:name=".communication.broadcast.DeliveryBroadcastReceiver">
             <intent-filter>
                 <action android:name="message_delivery" />
             </intent-filter>
         </receiver>
         <!--SMS Receiver-->
-        <receiver android:name="com.lukaspaczos.emergencynumber.broadcast.receiver.NewSmsBroadcastReceiver"
+        <receiver android:name=".communication.broadcast.NewSmsBroadcastReceiver"
             android:permission="android.permission.BROADCAST_SMS">
             <intent-filter>
                 <action android:name="android.provider.Telephony.SMS_RECEIVED" />

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/broadcast/DeliveryBroadcastReceiver.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/broadcast/DeliveryBroadcastReceiver.java
@@ -1,4 +1,4 @@
-package com.lukaspaczos.emergencynumber.broadcast.receiver;
+package com.lukaspaczos.emergencynumber.communication.broadcast;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/broadcast/NewSmsBroadcastReceiver.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/broadcast/NewSmsBroadcastReceiver.java
@@ -1,4 +1,4 @@
-package com.lukaspaczos.emergencynumber.broadcast.receiver;
+package com.lukaspaczos.emergencynumber.communication.broadcast;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/broadcast/SendBroadcastReceiver.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/broadcast/SendBroadcastReceiver.java
@@ -1,4 +1,4 @@
-package com.lukaspaczos.emergencynumber.broadcast.receiver;
+package com.lukaspaczos.emergencynumber.communication.broadcast;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/network/api/numbers/EmergencyNumbersApi.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/network/api/numbers/EmergencyNumbersApi.java
@@ -1,0 +1,37 @@
+package com.lukaspaczos.emergencynumber.communication.network.api.numbers;
+
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
+/**
+ * Created by lukas on 14.11.17
+ */
+
+public class EmergencyNumbersApi {
+
+    public static EmergencyNumbersApi instance;
+
+    public static EmergencyNumbersApi getInstance() {
+        if (instance == null)
+            instance = new EmergencyNumbersApi();
+
+        return instance;
+    }
+
+    public interface EmergencyNumbersService {
+        @GET("country/{countryCode}")
+        Call<EmergencyNumbersPOJO> getNumbers(@Path("countryCode") String countryCode);
+    }
+
+    private EmergencyNumbersService service = new Retrofit.Builder()
+            .baseUrl("http://emergencynumberapi.com/api/")
+            .addConverterFactory(GsonConverterFactory.create())
+            .build().create(EmergencyNumbersService.class);
+
+    public EmergencyNumbersService getService() {
+        return service;
+    }
+}

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/network/api/numbers/EmergencyNumbersPOJO.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/communication/network/api/numbers/EmergencyNumbersPOJO.java
@@ -1,0 +1,310 @@
+package com.lukaspaczos.emergencynumber.communication.network.api.numbers;
+
+import java.util.List;
+
+/**
+ * Created by lukas on 14.11.17
+ */
+
+public class EmergencyNumbersPOJO {
+
+    /**
+     * disclaimer : The data from this API is provided without any claims of accuracy, you should use this data as guidance, and do your own due diligence.
+     * error :
+     * data : {"country":{"name":"Poland","ISOCode":"PL","ISONumeric":"616"},"ambulance":{"all":["999"],"gsm":null,"fixed":null},"fire":{"all":["998"],"gsm":null,"fixed":null},"police":{"all":["997"],"gsm":null,"fixed":null},"dispatch":{"all":[""],"gsm":null,"fixed":null},"member_112":true,"localOnly":false,"nodata":false}
+     */
+
+    private String disclaimer;
+    private String error;
+    private DataBean data;
+
+    public String getDisclaimer() {
+        return disclaimer;
+    }
+
+    public void setDisclaimer(String disclaimer) {
+        this.disclaimer = disclaimer;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public DataBean getData() {
+        return data;
+    }
+
+    public void setData(DataBean data) {
+        this.data = data;
+    }
+
+    public static class DataBean {
+        /**
+         * country : {"name":"Poland","ISOCode":"PL","ISONumeric":"616"}
+         * ambulance : {"all":["999"],"gsm":null,"fixed":null}
+         * fire : {"all":["998"],"gsm":null,"fixed":null}
+         * police : {"all":["997"],"gsm":null,"fixed":null}
+         * dispatch : {"all":[""],"gsm":null,"fixed":null}
+         * member_112 : true
+         * localOnly : false
+         * nodata : false
+         */
+
+        private CountryBean country;
+        private AmbulanceBean ambulance;
+        private FireBean fire;
+        private PoliceBean police;
+        private DispatchBean dispatch;
+        private boolean member_112;
+        private boolean localOnly;
+        private boolean nodata;
+
+        public CountryBean getCountry() {
+            return country;
+        }
+
+        public void setCountry(CountryBean country) {
+            this.country = country;
+        }
+
+        public AmbulanceBean getAmbulance() {
+            return ambulance;
+        }
+
+        public void setAmbulance(AmbulanceBean ambulance) {
+            this.ambulance = ambulance;
+        }
+
+        public FireBean getFire() {
+            return fire;
+        }
+
+        public void setFire(FireBean fire) {
+            this.fire = fire;
+        }
+
+        public PoliceBean getPolice() {
+            return police;
+        }
+
+        public void setPolice(PoliceBean police) {
+            this.police = police;
+        }
+
+        public DispatchBean getDispatch() {
+            return dispatch;
+        }
+
+        public void setDispatch(DispatchBean dispatch) {
+            this.dispatch = dispatch;
+        }
+
+        public boolean isMember_112() {
+            return member_112;
+        }
+
+        public void setMember_112(boolean member_112) {
+            this.member_112 = member_112;
+        }
+
+        public boolean isLocalOnly() {
+            return localOnly;
+        }
+
+        public void setLocalOnly(boolean localOnly) {
+            this.localOnly = localOnly;
+        }
+
+        public boolean isNodata() {
+            return nodata;
+        }
+
+        public void setNodata(boolean nodata) {
+            this.nodata = nodata;
+        }
+
+        public static class CountryBean {
+            /**
+             * name : Poland
+             * ISOCode : PL
+             * ISONumeric : 616
+             */
+
+            private String name;
+            private String ISOCode;
+            private String ISONumeric;
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getISOCode() {
+                return ISOCode;
+            }
+
+            public void setISOCode(String ISOCode) {
+                this.ISOCode = ISOCode;
+            }
+
+            public String getISONumeric() {
+                return ISONumeric;
+            }
+
+            public void setISONumeric(String ISONumeric) {
+                this.ISONumeric = ISONumeric;
+            }
+        }
+
+        public static class AmbulanceBean {
+            /**
+             * all : ["999"]
+             * gsm : null
+             * fixed : null
+             */
+
+            private List<String> gsm;
+            private List<String> fixed;
+            private List<String> all;
+
+            public List<String> getGsm() {
+                return gsm;
+            }
+
+            public void setGsm(List<String> gsm) {
+                this.gsm = gsm;
+            }
+
+            public List<String> getFixed() {
+                return fixed;
+            }
+
+            public void setFixed(List<String> fixed) {
+                this.fixed = fixed;
+            }
+
+            public List<String> getAll() {
+                return all;
+            }
+
+            public void setAll(List<String> all) {
+                this.all = all;
+            }
+        }
+
+        public static class FireBean {
+            /**
+             * all : ["998"]
+             * gsm : null
+             * fixed : null
+             */
+
+            private List<String> gsm;
+            private List<String> fixed;
+            private List<String> all;
+
+            public List<String> getGsm() {
+                return gsm;
+            }
+
+            public void setGsm(List<String> gsm) {
+                this.gsm = gsm;
+            }
+
+            public List<String> getFixed() {
+                return fixed;
+            }
+
+            public void setFixed(List<String> fixed) {
+                this.fixed = fixed;
+            }
+
+            public List<String> getAll() {
+                return all;
+            }
+
+            public void setAll(List<String> all) {
+                this.all = all;
+            }
+        }
+
+        public static class PoliceBean {
+            /**
+             * all : ["997"]
+             * gsm : null
+             * fixed : null
+             */
+
+            private List<String> gsm;
+            private List<String> fixed;
+            private List<String> all;
+
+            public List<String> getGsm() {
+                return gsm;
+            }
+
+            public void setGsm(List<String> gsm) {
+                this.gsm = gsm;
+            }
+
+            public List<String> getFixed() {
+                return fixed;
+            }
+
+            public void setFixed(List<String> fixed) {
+                this.fixed = fixed;
+            }
+
+            public List<String> getAll() {
+                return all;
+            }
+
+            public void setAll(List<String> all) {
+                this.all = all;
+            }
+        }
+
+        public static class DispatchBean {
+            /**
+             * all : [""]
+             * gsm : null
+             * fixed : null
+             */
+
+            private List<String> gsm;
+            private List<String> fixed;
+            private List<String> all;
+
+            public List<String> getGsm() {
+                return gsm;
+            }
+
+            public void setGsm(List<String> gsm) {
+                this.gsm = gsm;
+            }
+
+            public List<String> getFixed() {
+                return fixed;
+            }
+
+            public void setFixed(List<String> fixed) {
+                this.fixed = fixed;
+            }
+
+            public List<String> getAll() {
+                return all;
+            }
+
+            public void setAll(List<String> all) {
+                this.all = all;
+            }
+        }
+    }
+}

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/launcher/BeginFragment.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/launcher/BeginFragment.java
@@ -52,6 +52,7 @@ public class BeginFragment extends Fragment {
     private EditText mEmailView;
     private CheckBox mRulesView;
     private TextView mRulesTextView;
+    private Button mChangeNumberButton;
 
     public BeginFragment() {
         // Required empty public constructor
@@ -81,6 +82,7 @@ public class BeginFragment extends Fragment {
         mEmailView = (EditText) rootView.findViewById(R.id.email);
         mRulesView = (CheckBox) rootView.findViewById(R.id.register_rules);
         mRulesTextView = (TextView) rootView.findViewById(R.id.register_rules_text);
+        mChangeNumberButton = rootView.findViewById(R.id.begin_change_number_button);
 
         Button mRegisterButton = (Button) rootView.findViewById(R.id.continue_button);
         mRegisterButton.setOnClickListener(new View.OnClickListener() {
@@ -115,6 +117,15 @@ public class BeginFragment extends Fragment {
         mRulesTextView.setText(sp);
         mRulesTextView.setMovementMethod(LinkMovementMethod.getInstance());
         mRulesTextView.setHighlightColor(ContextCompat.getColor(getActivity(), R.color.primary_white_text));
+
+        mChangeNumberButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                view.setVisibility(View.GONE);
+                mNumberView.setEnabled(true);
+                mNumberView.setText("");
+            }
+        });
 
         return rootView;
     }
@@ -175,6 +186,7 @@ public class BeginFragment extends Fragment {
                         if (!fetchedNumber.isEmpty()) {
                             mNumberView.setText(fetchedNumber);
                             mNumberView.setEnabled(false);
+                            mChangeNumberButton.setVisibility(View.VISIBLE);
                         }
 
                     } else {

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/launcher/BeginFragment.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/launcher/BeginFragment.java
@@ -1,6 +1,5 @@
 package com.lukaspaczos.emergencynumber.launcher;
 
-import android.accounts.NetworkErrorException;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
@@ -13,7 +12,6 @@ import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.text.style.ClickableSpan;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -23,24 +21,17 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.crashlytics.android.Crashlytics;
 import com.lukaspaczos.emergencynumber.R;
-import com.lukaspaczos.emergencynumber.communication.network.api.numbers.EmergencyNumbersApi;
-import com.lukaspaczos.emergencynumber.communication.network.api.numbers.EmergencyNumbersPOJO;
-import com.lukaspaczos.emergencynumber.util.NetworkUtils;
 import com.lukaspaczos.emergencynumber.util.Pref;
 import com.lukaspaczos.emergencynumber.util.StringUtils;
 import com.lukaspaczos.emergencynumber.util.UserInterfaceUtils;
 
 import java.util.Locale;
 
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
-
 public class BeginFragment extends Fragment {
 
     public static final String TAG = "begin_fragment";
+    public static final String FETCHED_NUMBER_ARG = "fetched_number_arg";
 
     private OnFragmentInteractionListener mListener;
 
@@ -54,13 +45,16 @@ public class BeginFragment extends Fragment {
     private TextView mRulesTextView;
     private Button mChangeNumberButton;
 
+    private String fetchedNumber = "";
+
     public BeginFragment() {
         // Required empty public constructor
     }
 
-    public static BeginFragment newInstance() {
+    public static BeginFragment newInstance(String fetchedNumber) {
         BeginFragment fragment = new BeginFragment();
         Bundle args = new Bundle();
+        args.putString(FETCHED_NUMBER_ARG, fetchedNumber);
         fragment.setArguments(args);
         return fragment;
     }
@@ -69,6 +63,7 @@ public class BeginFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
+            fetchedNumber = getArguments().getString(FETCHED_NUMBER_ARG);
         }
     }
 
@@ -127,6 +122,15 @@ public class BeginFragment extends Fragment {
             }
         });
 
+        if (fetchedNumber.isEmpty()) {
+            Toast.makeText(getActivity(), R.string.emergency_number_api_no_country, Toast.LENGTH_LONG).show();
+            mChangeNumberButton.setVisibility(View.GONE);
+        } else {
+            mNumberView.setText(fetchedNumber);
+            mNumberView.setEnabled(false);
+            mChangeNumberButton.setVisibility(View.VISIBLE);
+        }
+
         return rootView;
     }
 
@@ -145,81 +149,6 @@ public class BeginFragment extends Fragment {
     public void onDetach() {
         super.onDetach();
         mListener = null;
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
-
-        fetchEmergencyNumbersData();
-    }
-
-    private void fetchEmergencyNumbersData() {
-        String countryCode = NetworkUtils.getUserCountry(getActivity());
-        if (countryCode == null || countryCode.isEmpty()) {
-            Toast.makeText(getActivity(), R.string.emergency_number_api_no_country, Toast.LENGTH_LONG).show();
-            return;
-        }
-
-        Call<EmergencyNumbersPOJO> call = EmergencyNumbersApi.getInstance().getService().getNumbers(countryCode);
-        call.enqueue(new Callback<EmergencyNumbersPOJO>() {
-            @Override
-            public void onResponse(Call<EmergencyNumbersPOJO> call, Response<EmergencyNumbersPOJO> response) {
-                if (response.isSuccessful()) {
-                    String errorMsg = response.body().getError();
-                    if (errorMsg == null || errorMsg.isEmpty()) {
-                        EmergencyNumbersPOJO.DataBean dataBean = response.body().getData();
-                        String fetchedNumber = "";
-                        EmergencyNumbersPOJO.DataBean.DispatchBean dispatchBean = dataBean.getDispatch();
-                        if (dataBean.isMember_112()) {
-                            fetchedNumber = "112";
-                        } else if (dispatchBean.getAll() != null && !dispatchBean.getAll().isEmpty() && !dispatchBean.getAll().get(0).isEmpty()) {
-                            fetchedNumber = dispatchBean.getAll().get(0);
-                        } else if (dispatchBean.getGsm() != null && !dispatchBean.getGsm().isEmpty() && !dispatchBean.getGsm().get(0).isEmpty()) {
-                            fetchedNumber = dispatchBean.getGsm().get(0);
-                        } else if (dataBean.getPolice().getAll() != null && !dataBean.getPolice().getAll().isEmpty() && !dataBean.getPolice().getAll().get(0).isEmpty()) {
-                            fetchedNumber = dataBean.getPolice().getAll().get(0);
-                        } else if (dataBean.getAmbulance().getAll() != null && !dataBean.getAmbulance().getAll().isEmpty() && !dataBean.getAmbulance().getAll().get(0).isEmpty()) {
-                            fetchedNumber = dataBean.getAmbulance().getAll().get(0);
-                        }
-
-                        if (!fetchedNumber.isEmpty()) {
-                            mNumberView.setText(fetchedNumber);
-                            mNumberView.setEnabled(false);
-                            mChangeNumberButton.setVisibility(View.VISIBLE);
-                        }
-
-                    } else {
-                        Toast.makeText(getActivity(), R.string.emergency_number_api_no_country, Toast.LENGTH_LONG).show();
-                        Crashlytics.logException(new NetworkErrorException(call.request().toString()));
-                    }
-                } else {
-                    Toast.makeText(getActivity(), R.string.emergency_number_api_no_country, Toast.LENGTH_LONG).show();
-                    Crashlytics.logException(new NetworkErrorException(call.request().toString()));
-                }
-            }
-
-            @Override
-            public void onFailure(final Call<EmergencyNumbersPOJO> call, final Throwable t) {
-                NetworkUtils.hasActiveInternetConnection(new NetworkUtils.NetworkStateListener() {
-                    @Override
-                    public void hasNetworkConnection(boolean result) {
-                        if (result) {
-                            Log.d("API REQUEST", "FAILURE: " + t);
-                            Crashlytics.logException(new NetworkErrorException(call.request().toString() + " - has internet"));
-                        } else {
-                            Crashlytics.logException(new NetworkErrorException(call.request().toString() + " - no internet"));
-                            getActivity().runOnUiThread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    Toast.makeText(getActivity(), R.string.emergency_number_api_no_country, Toast.LENGTH_LONG).show();
-                                }
-                            });
-                        }
-                    }
-                });
-            }
-        });
     }
 
     private void attemptRegister() {

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/launcher/LauncherActivity.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/launcher/LauncherActivity.java
@@ -1,6 +1,7 @@
 package com.lukaspaczos.emergencynumber.launcher;
 
 import android.Manifest;
+import android.accounts.NetworkErrorException;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.content.DialogInterface;
@@ -17,26 +18,43 @@ import android.view.animation.Animation;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 
+import com.crashlytics.android.Crashlytics;
 import com.lukaspaczos.emergencynumber.MainActivity;
 import com.lukaspaczos.emergencynumber.R;
+import com.lukaspaczos.emergencynumber.communication.network.api.numbers.EmergencyNumbersApi;
+import com.lukaspaczos.emergencynumber.communication.network.api.numbers.EmergencyNumbersPOJO;
+import com.lukaspaczos.emergencynumber.util.NetworkUtils;
 import com.lukaspaczos.emergencynumber.util.Pref;
 import com.lukaspaczos.emergencynumber.util.ResizeAnimation;
+
+import java.util.Locale;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class LauncherActivity extends AppCompatActivity implements OnFragmentInteractionListener {
 
     private static final int PERMISSIONS_REQUEST_CODE = 2536;
+    private static final String[] permissionsArray = new String[]{
+            Manifest.permission.READ_PHONE_STATE,
+            Manifest.permission.ACCESS_NETWORK_STATE,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.RECEIVE_SMS,
+            Manifest.permission.SEND_SMS};
 
     private Intent startIntent;
 
     private View contentFrame;
-
     private ProgressBar mProgressView;
-
     private ImageView logo;
     private Animation shrinkAnimation;
     private Animation growAnimation;
     private boolean isShrunk = false;
     private boolean canBack = false;
+
+    private String fetchedEmergencyNumber = "";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -56,26 +74,23 @@ public class LauncherActivity extends AppCompatActivity implements OnFragmentInt
         growAnimation = new ResizeAnimation(logo, sizeSmall, sizeSmall, sizeBig, sizeBig);
         growAnimation.setFillAfter(true);
 
-        if (
-                ActivityCompat.checkSelfPermission(this, Manifest.permission.RECEIVE_SMS) != PackageManager.PERMISSION_GRANTED
-                        || ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
-                        || ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED
-                        || ActivityCompat.checkSelfPermission(this, Manifest.permission.SEND_SMS) != PackageManager.PERMISSION_GRANTED
-                        || ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_NETWORK_STATE) != PackageManager.PERMISSION_GRANTED
-                        || ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_PHONE_STATE) != PackageManager.PERMISSION_GRANTED) {
-
-            ActivityCompat.requestPermissions(this,
-                    new String[]{
-                            Manifest.permission.READ_PHONE_STATE,
-                            Manifest.permission.ACCESS_NETWORK_STATE,
-                            Manifest.permission.ACCESS_FINE_LOCATION,
-                            Manifest.permission.ACCESS_COARSE_LOCATION,
-                            Manifest.permission.RECEIVE_SMS,
-                            Manifest.permission.SEND_SMS},
-                    PERMISSIONS_REQUEST_CODE);
+        for (String permission : permissionsArray) {
+            if (ActivityCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(
+                        this,
+                        permissionsArray,
+                        PERMISSIONS_REQUEST_CODE
+                );
+                break;
+            }
         }
 
-        verifiedInit(savedInstanceState);
+        if (savedInstanceState == null) {
+            startStart();
+        }
+
+        showProgress(true);
+        fetchEmergencyNumbersData();
     }
 
     @Override
@@ -97,15 +112,11 @@ public class LauncherActivity extends AppCompatActivity implements OnFragmentInt
                 dialog.setNeutralButton(R.string.no_permissions_retry, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
-                        ActivityCompat.requestPermissions(LauncherActivity.this,
-                                new String[]{
-                                        Manifest.permission.READ_PHONE_STATE,
-                                        Manifest.permission.ACCESS_NETWORK_STATE,
-                                        Manifest.permission.ACCESS_FINE_LOCATION,
-                                        Manifest.permission.ACCESS_COARSE_LOCATION,
-                                        Manifest.permission.RECEIVE_SMS,
-                                        Manifest.permission.SEND_SMS},
-                                PERMISSIONS_REQUEST_CODE);
+                        ActivityCompat.requestPermissions(
+                                LauncherActivity.this,
+                                permissionsArray,
+                                PERMISSIONS_REQUEST_CODE
+                        );
                     }
                 });
                 dialog.show();
@@ -115,15 +126,105 @@ public class LauncherActivity extends AppCompatActivity implements OnFragmentInt
         }
     }
 
-    private void verifiedInit(final Bundle savedInstanceState) {
+    private void verifiedInit() {
         final String name = Pref.getString(Pref.NAME, "");
         final String number = Pref.getString(Pref.EMERGENCY_PHONE_NUMBER, "");
 
         if (!name.isEmpty() && !number.isEmpty()) {
-            startMainActivity();
-        } else if (savedInstanceState == null) {
-            startStart();
+            if (number.equals(fetchedEmergencyNumber)
+                    || fetchedEmergencyNumber.isEmpty()
+                    || !Pref.getBoolean(Pref.SHOW_NUMBER_CHANGED_DIALOG, true)) {
+                startMainActivity();
+            } else {
+                AlertDialog.Builder dialog = new AlertDialog.Builder(this);
+                dialog.setCancelable(false);
+                dialog.setTitle(R.string.init_update_number_dialog_title);
+                dialog.setMessage(String.format(Locale.getDefault(),
+                        getString(R.string.init_update_number_dialog_msg),
+                        number,
+                        fetchedEmergencyNumber));
+                dialog.setPositiveButton(R.string.init_update_number_dialog_positive, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        Pref.putString(Pref.EMERGENCY_PHONE_NUMBER, fetchedEmergencyNumber);
+                        startMainActivity();
+                    }
+                });
+                dialog.setNegativeButton(R.string.init_update_number_dialog_negative, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        startMainActivity();
+                    }
+                });
+                dialog.setNeutralButton(R.string.init_update_number_dialog_neutral, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        Pref.putBoolean(Pref.SHOW_NUMBER_CHANGED_DIALOG, false);
+                        startMainActivity();
+                    }
+                });
+                dialog.show();
+            }
         }
+    }
+
+    private void fetchEmergencyNumbersData() {
+        String countryCode = NetworkUtils.getUserCountry(this);
+        if (countryCode == null || countryCode.isEmpty()) {
+            showProgress(false);
+            verifiedInit();
+            return;
+        }
+
+        Call<EmergencyNumbersPOJO> call = EmergencyNumbersApi.getInstance().getService().getNumbers(countryCode);
+        call.enqueue(new Callback<EmergencyNumbersPOJO>() {
+            @Override
+            public void onResponse(Call<EmergencyNumbersPOJO> call, Response<EmergencyNumbersPOJO> response) {
+                if (response.isSuccessful()) {
+                    String errorMsg = response.body().getError();
+                    if (errorMsg == null || errorMsg.isEmpty()) {
+                        EmergencyNumbersPOJO.DataBean dataBean = response.body().getData();
+                        EmergencyNumbersPOJO.DataBean.DispatchBean dispatchBean = dataBean.getDispatch();
+                        if (dataBean.isMember_112()) {
+                            fetchedEmergencyNumber = "112";
+                        } else if (dispatchBean.getAll() != null && !dispatchBean.getAll().isEmpty() && !dispatchBean.getAll().get(0).isEmpty()) {
+                            fetchedEmergencyNumber = dispatchBean.getAll().get(0);
+                        } else if (dispatchBean.getGsm() != null && !dispatchBean.getGsm().isEmpty() && !dispatchBean.getGsm().get(0).isEmpty()) {
+                            fetchedEmergencyNumber = dispatchBean.getGsm().get(0);
+                        } else if (dataBean.getPolice().getAll() != null && !dataBean.getPolice().getAll().isEmpty() && !dataBean.getPolice().getAll().get(0).isEmpty()) {
+                            fetchedEmergencyNumber = dataBean.getPolice().getAll().get(0);
+                        } else if (dataBean.getAmbulance().getAll() != null && !dataBean.getAmbulance().getAll().isEmpty() && !dataBean.getAmbulance().getAll().get(0).isEmpty()) {
+                            fetchedEmergencyNumber = dataBean.getAmbulance().getAll().get(0);
+                        }
+
+                    } else {
+                        Crashlytics.logException(new NetworkErrorException(call.request().toString()));
+                    }
+                } else {
+                    Crashlytics.logException(new NetworkErrorException(call.request().toString()));
+                }
+
+                showProgress(false);
+                verifiedInit();
+            }
+
+            @Override
+            public void onFailure(final Call<EmergencyNumbersPOJO> call, final Throwable t) {
+                NetworkUtils.hasActiveInternetConnection(new NetworkUtils.NetworkStateListener() {
+                    @Override
+                    public void hasNetworkConnection(boolean result) {
+                        if (result) {
+                            Crashlytics.logException(new NetworkErrorException(call.request().toString() + " - has internet"));
+                        } else {
+                            Crashlytics.logException(new NetworkErrorException(call.request().toString() + " - no internet"));
+                        }
+                    }
+                });
+
+                showProgress(false);
+                verifiedInit();
+            }
+        });
     }
 
     @Override
@@ -143,11 +244,12 @@ public class LauncherActivity extends AppCompatActivity implements OnFragmentInt
 
         getSupportFragmentManager()
                 .beginTransaction()
-                .replace(R.id.content_frame, BeginFragment.newInstance(), BeginFragment.TAG)
+                .replace(R.id.content_frame, BeginFragment.newInstance(fetchedEmergencyNumber), BeginFragment.TAG)
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                 .commit();
     }
 
+    @Override
     public void startMainActivity() {
         Intent intent;
         intent = new Intent(this, MainActivity.class);

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/launcher/LauncherActivity.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/launcher/LauncherActivity.java
@@ -73,8 +73,9 @@ public class LauncherActivity extends AppCompatActivity implements OnFragmentInt
                             Manifest.permission.RECEIVE_SMS,
                             Manifest.permission.SEND_SMS},
                     PERMISSIONS_REQUEST_CODE);
-        } else
-            verifiedInit(savedInstanceState);
+        }
+
+        verifiedInit(savedInstanceState);
     }
 
     @Override
@@ -112,13 +113,11 @@ public class LauncherActivity extends AppCompatActivity implements OnFragmentInt
                 return;
             }
         }
-
-        verifiedInit(null);
     }
 
-    private void verifiedInit(Bundle savedInstanceState) {
-        String name = Pref.getString(Pref.NAME, "");
-        String number = Pref.getString(Pref.EMERGENCY_PHONE_NUMBER, "");
+    private void verifiedInit(final Bundle savedInstanceState) {
+        final String name = Pref.getString(Pref.NAME, "");
+        final String number = Pref.getString(Pref.EMERGENCY_PHONE_NUMBER, "");
 
         if (!name.isEmpty() && !number.isEmpty()) {
             startMainActivity();

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/util/NetworkUtils.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/util/NetworkUtils.java
@@ -3,13 +3,13 @@ package com.lukaspaczos.emergencynumber.util;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.telephony.TelephonyManager;
 import android.util.Log;
 
 import com.lukaspaczos.emergencynumber.App;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 /**
@@ -53,6 +53,31 @@ public class NetworkUtils {
 
     public interface NetworkStateListener {
         void hasNetworkConnection(boolean result);
+    }
+
+    /**
+     * Get ISO 3166-1 alpha-2 country code for this device (or null if not available)
+     *
+     * @param context Context reference to get the TelephonyManager instance from
+     * @return country code or null
+     */
+    public static String getUserCountry(Context context) {
+        final TelephonyManager tm = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        if (tm != null) {
+            if (tm.getPhoneType() != TelephonyManager.PHONE_TYPE_CDMA) { // device is not 3G (would be unreliable)
+                String networkCountry = tm.getNetworkCountryIso();
+                if (networkCountry != null && networkCountry.length() == 2) { // network country code is available
+                    return networkCountry.toUpperCase();
+                }
+            }
+
+            final String simCountry = tm.getSimCountryIso();
+            if (simCountry != null && simCountry.length() == 2) { // SIM country code is available
+                return simCountry.toUpperCase();
+            }
+        }
+
+        return null;
     }
 
 }

--- a/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/util/Pref.java
+++ b/EmergencyNumber/src/main/java/com/lukaspaczos/emergencynumber/util/Pref.java
@@ -19,7 +19,7 @@ public class Pref {
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
-            NAME, EMERGENCY_PHONE_NUMBER, EMAIL
+            NAME, EMERGENCY_PHONE_NUMBER, EMAIL, SHOW_NUMBER_CHANGED_DIALOG
     })
 
     public @interface Type {}
@@ -27,6 +27,7 @@ public class Pref {
     public static final String NAME = "pref_name";
     public static final String EMERGENCY_PHONE_NUMBER = "pref_emergency_phone_number";
     public static final String EMAIL = "pref_email";
+    public static final String SHOW_NUMBER_CHANGED_DIALOG = "show_number_changed_dialog";
 
     private static SharedPreferences preferences = App.getContext().getSharedPreferences(App.getContext()
             .getString(R.string.preferences_DB_name), Context.MODE_PRIVATE);

--- a/EmergencyNumber/src/main/res/layout/fragment_begin.xml
+++ b/EmergencyNumber/src/main/res/layout/fragment_begin.xml
@@ -23,21 +23,38 @@
 
     </android.support.design.widget.TextInputLayout>
 
-    <android.support.design.widget.TextInputLayout
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <EditText
-            android:id="@+id/begin_number"
+        <android.support.design.widget.TextInputLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/prompt_emergency_phone"
-            android:imeOptions="actionNext"
-            android:inputType="number"
-            android:maxLines="1"
-            android:textColor="@android:color/white" />
+            android:layout_height="wrap_content">
 
-    </android.support.design.widget.TextInputLayout>
+            <EditText
+                android:id="@+id/begin_number"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/prompt_emergency_phone"
+                android:imeOptions="actionNext"
+                android:inputType="number"
+                android:maxLines="1"
+                android:textColor="@android:color/white" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <Button
+            android:id="@+id/begin_change_number_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:layout_centerVertical="true"
+            android:background="?android:attr/selectableItemBackground"
+            android:text="@string/begin_change_number"
+            android:textColor="@android:color/white"
+            android:textSize="12sp" />
+
+    </RelativeLayout>
 
     <android.support.design.widget.TextInputLayout
         android:layout_width="match_parent"

--- a/EmergencyNumber/src/main/res/values-pl/strings.xml
+++ b/EmergencyNumber/src/main/res/values-pl/strings.xml
@@ -121,6 +121,7 @@
     <string name="first_aid_url">http://www.mz.gov.pl/system-ochrony-zdrowia/panstwowe-ratownictwo-medyczne/pierwsza-pomoc/sposob-udzielania-pierwszej-pomocy-w-wybranych-naglych-wypadkach/</string>
     <string name="rules_url">file:///android_asset/rules_website.html</string>
     <string name="app_logo">Logo aplikacji</string>
+
     <string name="action_start_begin">ROZPOCZNIJ</string>
     <string name="prompt_emergency_phone">Numer alarmowy w Twoim kraju</string>
     <string name="send_message_desc">Wyślij wiadomość</string>
@@ -128,6 +129,13 @@
     <string name="location_address">Adres…</string>
     <string name="error_sending_report">Wystąpił błąd. Sprawdź poprawność numeru alarmowego w ustawieniach i spróbuj ponownie.</string>
     <string name="chat_operator">Operator</string>
+
+    <!--EMERGENCY NUMBER-->
     <string name="emergency_number_api_no_country">Nie udało nam się ustalić Twojej pozycji, żeby określić numer alarmowy. Wprowadź ręcznie.</string>
     <string name="begin_change_number">ZMIEŃ</string>
+    <string name="init_update_number_dialog_title">Zaktualizuj numer alarmowy</string>
+    <string name="init_update_number_dialog_msg">Zauwazyliśmy, że numer alarmowy dla twojej lokalizacji się zmienił. Czy chcesz go zaktualizować z %s na %s?</string>
+    <string name="init_update_number_dialog_positive">Zaktualizuj</string>
+    <string name="init_update_number_dialog_negative">Pomiń</string>
+    <string name="init_update_number_dialog_neutral">Nie pokazuj więcej</string>
 </resources>

--- a/EmergencyNumber/src/main/res/values-pl/strings.xml
+++ b/EmergencyNumber/src/main/res/values-pl/strings.xml
@@ -129,4 +129,5 @@
     <string name="error_sending_report">Wystąpił błąd. Sprawdź poprawność numeru alarmowego w ustawieniach i spróbuj ponownie.</string>
     <string name="chat_operator">Operator</string>
     <string name="emergency_number_api_no_country">Nie udało nam się ustalić Twojej pozycji, żeby określić numer alarmowy. Wprowadź ręcznie.</string>
+    <string name="begin_change_number">ZMIEŃ</string>
 </resources>

--- a/EmergencyNumber/src/main/res/values-pl/strings.xml
+++ b/EmergencyNumber/src/main/res/values-pl/strings.xml
@@ -122,10 +122,11 @@
     <string name="rules_url">file:///android_asset/rules_website.html</string>
     <string name="app_logo">Logo aplikacji</string>
     <string name="action_start_begin">ROZPOCZNIJ</string>
-    <string name="prompt_emergency_phone">Numer alarmowy</string>
+    <string name="prompt_emergency_phone">Numer alarmowy w Twoim kraju</string>
     <string name="send_message_desc">Wyślij wiadomość</string>
     <string name="location_use_custom">lub wpisz adres</string>
     <string name="location_address">Adres…</string>
     <string name="error_sending_report">Wystąpił błąd. Sprawdź poprawność numeru alarmowego w ustawieniach i spróbuj ponownie.</string>
     <string name="chat_operator">Operator</string>
+    <string name="emergency_number_api_no_country">Nie udało nam się ustalić Twojej pozycji, żeby określić numer alarmowy. Wprowadź ręcznie.</string>
 </resources>

--- a/EmergencyNumber/src/main/res/values/strings.xml
+++ b/EmergencyNumber/src/main/res/values/strings.xml
@@ -96,4 +96,5 @@
     <string name="location_address">Address…</string>
     <string name="chat_operator">Operator</string>
     <string name="emergency_number_api_no_country">We couldn\'t establish your position to fetch emergency number. Please enter it yourself.</string>
+    <string name="begin_change_number">CHANGE</string>
 </resources>

--- a/EmergencyNumber/src/main/res/values/strings.xml
+++ b/EmergencyNumber/src/main/res/values/strings.xml
@@ -77,7 +77,7 @@
     <string name="web_view_error">Error occurred while loading first aid tips.</string>
     <string name="prompt_email">E-mail (optional)</string>
     <string name="prompt_name">Name</string>
-    <string name="prompt_emergency_phone">Emergency phone number</string>
+    <string name="prompt_emergency_phone">Country\'s emergency phone number</string>
     <string name="error_invalid_phone">Invalid phone number</string>
     <string name="error_invalid_email">Invalid e-mail</string>
     <string name="error_field_required">this field is required</string>
@@ -95,4 +95,5 @@
     <string name="location_use_custom">or put in an address</string>
     <string name="location_address">Address…</string>
     <string name="chat_operator">Operator</string>
+    <string name="emergency_number_api_no_country">We couldn\'t establish your position to fetch emergency number. Please enter it yourself.</string>
 </resources>

--- a/EmergencyNumber/src/main/res/values/strings.xml
+++ b/EmergencyNumber/src/main/res/values/strings.xml
@@ -97,4 +97,9 @@
     <string name="chat_operator">Operator</string>
     <string name="emergency_number_api_no_country">We couldn\'t establish your position to fetch emergency number. Please enter it yourself.</string>
     <string name="begin_change_number">CHANGE</string>
+    <string name="init_update_number_dialog_title">Update emergency number</string>
+    <string name="init_update_number_dialog_msg">We\'ve detected that emergency number changed for your area. Do you want to update it from %s to %s?</string>
+    <string name="init_update_number_dialog_positive">Update</string>
+    <string name="init_update_number_dialog_negative">Dismiss</string>
+    <string name="init_update_number_dialog_neutral">Don\'t show anymore</string>
 </resources>


### PR DESCRIPTION
Refs #6 
To fetch emergency numbers I'm using http://emergencynumberapi.com/ which data can be found and updated if necessary [here](https://github.com/EmergencyNumberAPI/data).
If there is no available data/internet connection I'm just letting a user type it in by hand.
There is also a button which enables to change auto-completed number for a different one.

The API takes a country code as a parameter. First I try to find one via BTS and if that doesn't return anything I use SIM's country code.

Currently, there is the following priority when it comes to choosing a number:
1. Use 112
2. Use any other uniform emergency number
3. Use Police number
4. Use Ambulance number

On every app start, there is a request for a number sent and compared to the local version. If there are any differences user can:
- update the number to a recently fetched
- leave the number unchanged
- leave the number unchanged and don't notify about changes anymore